### PR TITLE
Fixes #3 - Initialization of err and studyerr fails

### DIFF
--- a/regex.v
+++ b/regex.v
@@ -54,8 +54,8 @@ pub fn (r Regex) match_str(str string, pos int, options int) ?MatchData {
 	* options: the options as mentioned in the PCRE documentation
 */
 pub fn new_regex(source string, options int) ?Regex {
-	err := string{}
-	studyerr := string{}
+	err := ''
+	studyerr := ''
 	erroffset := 0
 	captures := 0
 


### PR DESCRIPTION
```
pcre/regex.v:57:9: error: cannot initialize builtin type `string`
   55 | */
   56 | pub fn new_regex(source string, options int) ?Regex {
   57 |     err := string{}
      |            ~~~~~~~~
   58 |     studyerr := string{}
   59 |     erroffset := 0
pcre/regex.v:58:14: error: cannot initialize builtin type `string`
   56 | pub fn new_regex(source string, options int) ?Regex {
   57 |     err := string{}
   58 |     studyerr := string{}
      |                 ~~~~~~~~
   59 |     erroffset := 0
   60 |     captures := 0
```