### PR TITLE
pcre: Implement MatchData iterator

### DIFF
--- a/match_data.v
+++ b/match_data.v
@@ -3,10 +3,12 @@ module pcre
 struct MatchData {
 pub:
 	re         &C.pcre // A pointer to pcre structure
+	regex      &Regex
 	ovector    []int
 	str        string
-	pos        int
 	group_size int
+mut:
+	pos int
 }
 
 // valid_group checks if group index is valid
@@ -45,4 +47,15 @@ pub fn (m MatchData) get_all() []string {
 		res << substr
 	}
 	return res
+}
+
+// next iterates over all pattern matches
+pub fn (mut m MatchData) next() ?MatchData {
+	if m0 := m.get(0) {
+		ret := m.regex.match_str(m.str, if m.pos == 0 { 0 } else { m.pos + m0.len - 1 },
+			m.regex.options) or { return none }
+		m.pos += m0.len
+		return ret
+	}
+	return none
 }

--- a/regex.v
+++ b/regex.v
@@ -5,6 +5,7 @@ pub:
 	re       &C.pcre       // A pointer to pcre structure
 	extra    &C.pcre_extra // A pointer to pcre_extra structure
 	captures int // The number of capture groups
+	options  int // Regex options
 }
 
 pub fn (r &Regex) free() {
@@ -34,6 +35,7 @@ pub fn (r Regex) match_str(str string, pos int, options int) ?MatchData {
 	}
 	return MatchData{
 		re: r.re
+		regex: &r
 		str: str
 		ovector: ovector
 		pos: pos
@@ -63,5 +65,5 @@ pub fn new_regex(source string, options int) ?Regex {
 		return error('Failed to study regex: ${err}')
 	}
 	C.pcre_fullinfo(re, 0, C.PCRE_INFO_CAPTURECOUNT, &captures)
-	return Regex{re, extra, captures}
+	return Regex{re, extra, captures, options}
 }

--- a/regex.v
+++ b/regex.v
@@ -1,5 +1,6 @@
 module pcre
 
+[heap]
 struct Regex {
 pub:
 	re       &C.pcre       // A pointer to pcre structure
@@ -22,7 +23,7 @@ pub fn (r &Regex) free() {
 // str: the string to test
 // pos: the position of the beginning of the string (default: 0)
 // options: the options as mentioned in the PCRE documentation
-pub fn (r Regex) match_str(str string, pos int, options int) ?MatchData {
+pub fn (r &Regex) match_str(str string, pos int, options int) ?MatchData {
 	if pos < 0 || pos >= str.len {
 		return error('Invalid position')
 	}
@@ -35,7 +36,7 @@ pub fn (r Regex) match_str(str string, pos int, options int) ?MatchData {
 	}
 	return MatchData{
 		re: r.re
-		regex: &r
+		regex: r
 		str: str
 		ovector: ovector
 		pos: pos

--- a/regex_test.v
+++ b/regex_test.v
@@ -17,3 +17,23 @@ fn test_match_after() {
 
 	r.free()
 }
+
+fn test_match_all() {
+	body := 'abcdef'
+	pattern := r'(.)'
+
+	mut re := new_regex(pattern, 0) or {
+		println('An error occured')
+		return
+	}
+
+	matches := re.match_str(body, 0, 0) or { return }
+
+	mut out := ''
+	for m in matches {
+		assert m.get_all().len == 1
+		out += m.get(0) or { 'error' }
+	}
+
+	assert out.str() == body.str()
+}


### PR DESCRIPTION
Makes possible iterate over matches.

```V
fn test_match_all() {
	body := 'abcdef'
	pattern := r'(.)'

	mut re := new_regex(pattern, 0) or {
		println('An error occured')
		return
	}

	matches := re.match_str(body, 0, 0) or { return }

	mut out := ''
	for m in matches {
		assert m.get_all().len == 1
		out += m.get(0) or { 'error' }
	}

	assert out.str() == body.str()
}
```